### PR TITLE
Clear liquid glass effect for pill menu

### DIFF
--- a/GlassticPackage/Sources/GlassticFeature/ContentView.swift
+++ b/GlassticPackage/Sources/GlassticFeature/ContentView.swift
@@ -223,41 +223,195 @@ private struct BottomPillMenu: View {
     @Binding var selectedTab: BottomTab
     let accentColor: Color
     let height: CGFloat
+    
     @State private var hoverTab: BottomTab?
     @State private var dragLocation: CGPoint?
     @State private var isDragging = false
     @State private var tabFrames: [BottomTab: CGRect] = [:]
+    @State private var containerFrame: CGRect = .zero
+    @State private var selectionOffset: CGFloat = 0
+    @State private var targetSelectionOffset: CGFloat = 0
+    @State private var selectionVelocity: CGFloat = 0
+    @State private var wobblePhase: CGFloat = 0
+    @State private var wobbleAmplitude: CGFloat = 0
+    @State private var time: CGFloat = 0
+    @State private var pressedTab: BottomTab?
+    @State private var blobScales: [BottomTab: CGFloat] = [:]
 
     var body: some View {
-        GlassEffectContainer(spacing: 40) {
-            HStack(spacing: 0) {
-                ForEach(BottomTab.allCases) { tab in
-                    tabButton(for: tab)
+        TimelineView(.animation(minimumInterval: 1.0 / 60.0)) { timeline in
+            let _ = updateAnimation(timeline.date)
+            
+            GlassEffectContainer(spacing: 40) {
+                ZStack {
+                    selectionBlobLayer
+                    
+                    HStack(spacing: 0) {
+                        ForEach(BottomTab.allCases) { tab in
+                            tabButton(for: tab)
+                        }
+                    }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 8)
                 }
+                .frame(height: height)
+                .background {
+                    pillBackground
+                }
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(
+                            key: ContainerFrameKey.self,
+                            value: proxy.frame(in: .named("pill"))
+                        )
+                    }
+                )
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .frame(height: height)
+            .coordinateSpace(name: "pill")
+            .contentShape(Capsule())
+            .simultaneousGesture(dragGesture)
+            .onPreferenceChange(TabFrameKey.self) { frames in
+                tabFrames = frames
+                updateSelectionTarget()
+            }
+            .onPreferenceChange(ContainerFrameKey.self) { frame in
+                containerFrame = frame
+                updateSelectionTarget()
+            }
+            .shadow(color: .black.opacity(0.5), radius: 24, x: 0, y: 12)
+            .shadow(color: accentColor.opacity(0.2), radius: 40, x: 0, y: 8)
+            .padding(.horizontal, 16)
+            .padding(.bottom, 8)
         }
-        .coordinateSpace(name: "pill")
-        .contentShape(Capsule())
-        .simultaneousGesture(dragGesture)
-        .onPreferenceChange(TabFrameKey.self) { tabFrames = $0 }
-        .shadow(color: .black.opacity(0.4), radius: 20, x: 0, y: 10)
-        .shadow(color: accentColor.opacity(0.15), radius: 30, x: 0, y: 5)
-        .padding(.horizontal, 16)
-        .padding(.bottom, 8)
+    }
+    
+    private func updateAnimation(_ date: Date) {
+        let dt: CGFloat = 1.0 / 60.0
+        time = CGFloat(date.timeIntervalSinceReferenceDate)
+        
+        wobblePhase += 8.0 * dt
+        if wobblePhase > .pi * 2 { wobblePhase -= .pi * 2 }
+        
+        wobbleAmplitude *= 0.92
+        if wobbleAmplitude < 0.001 { wobbleAmplitude = 0 }
+        
+        let displacement = selectionOffset - targetSelectionOffset
+        let springForce = -220.0 * displacement
+        let dampingForce = -0.7 * 220.0 * 2 * selectionVelocity
+        let acceleration = springForce + dampingForce
+        
+        selectionVelocity += acceleration * dt
+        selectionOffset += selectionVelocity * dt
+        
+        if abs(selectionVelocity) < 0.1 && abs(displacement) < 0.5 {
+            selectionOffset = targetSelectionOffset
+            selectionVelocity = 0
+        }
+    }
+    
+    private func updateSelectionTarget() {
+        guard let frame = tabFrames[selectedTab] else { return }
+        let newTarget = frame.midX
+        if abs(targetSelectionOffset - newTarget) > 1 {
+            wobbleAmplitude = min(wobbleAmplitude + 0.03, 0.06)
+        }
+        targetSelectionOffset = newTarget
+    }
+    
+    @ViewBuilder
+    private var selectionBlobLayer: some View {
+        if let frame = tabFrames[selectedTab] {
+            let stretchFactor = 1.0 + min(abs(selectionVelocity) * 0.0008, 0.15)
+            let wobbleX = sin(wobblePhase) * wobbleAmplitude * 8
+            let wobbleScaleX = 1.0 + cos(wobblePhase * 1.3) * wobbleAmplitude * 0.3
+            let wobbleScaleY = 1.0 + sin(wobblePhase * 0.9) * wobbleAmplitude * 0.2
+            
+            Capsule(style: .continuous)
+                .fill(
+                    RadialGradient(
+                        colors: [
+                            accentColor.opacity(0.4),
+                            accentColor.opacity(0.15),
+                            Color.clear
+                        ],
+                        center: .center,
+                        startRadius: 0,
+                        endRadius: frame.width * 0.7
+                    )
+                )
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(
+                            LinearGradient(
+                                colors: [
+                                    Color.white.opacity(0.4),
+                                    Color.white.opacity(0.1),
+                                    accentColor.opacity(0.3)
+                                ],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ),
+                            lineWidth: 1.5
+                        )
+                )
+                .frame(width: frame.width * stretchFactor * wobbleScaleX, height: frame.height * wobbleScaleY)
+                .position(x: selectionOffset + wobbleX, y: containerFrame.midY)
+                .blur(radius: 1)
+                .blendMode(.plusLighter)
+        }
+    }
+    
+    private var pillBackground: some View {
+        ZStack {
+            AnimatedCausticBackdrop(time: time, accentColor: accentColor)
+                .clipShape(Capsule(style: .continuous))
+            
+            Capsule(style: .continuous)
+                .fill(Color.white.opacity(0.03))
+                .clearLiquidGlass(
+                    cornerRadius: 0.15,
+                    refraction: 0.28,
+                    chromaticSpread: 0.07,
+                    edgeHighlight: 0.6,
+                    causticIntensity: 0.4,
+                    wobbleAmount: 0.015 + wobbleAmplitude * 0.6,
+                    wobbleFreq: 5.0,
+                    time: time,
+                    maxSampleOffset: CGSize(width: 120, height: 120)
+                )
+                .overlay(
+                    Capsule(style: .continuous)
+                        .stroke(
+                            LinearGradient(
+                                colors: [
+                                    Color.white.opacity(0.5),
+                                    Color.white.opacity(0.1),
+                                    Color.white.opacity(0.3)
+                                ],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            ),
+                            lineWidth: 1.5
+                        )
+                )
+        }
     }
     
     @ViewBuilder
     private func tabButton(for tab: BottomTab) -> some View {
         let isSelected = selectedTab == tab
         let isHovered = hoverTab == tab
-        let magnifyScale: CGFloat = isSelected ? 1.08 : (isHovered ? 1.03 : 1.0)
+        let isPressed = pressedTab == tab
+        let blobScale = blobScales[tab] ?? 1.0
+        
+        let baseScale: CGFloat = isSelected ? 1.1 : (isHovered ? 1.05 : 1.0)
+        let pressScale: CGFloat = isPressed ? 0.92 : 1.0
+        let finalScale = baseScale * pressScale * blobScale
 
-        let base = Button {
+        Button {
             withAnimation(.bouncy(duration: 0.4)) {
                 selectedTab = tab
+                wobbleAmplitude = 0.05
             }
         } label: {
             VStack(spacing: 4) {
@@ -267,13 +421,13 @@ private struct BottomPillMenu: View {
                 Text(tab.title)
                     .font(.system(size: 10, weight: .semibold))
             }
-            .foregroundStyle(isSelected ? Color.white : .white.opacity(0.6))
-            .shadow(color: isSelected ? accentColor.opacity(0.9) : .clear, radius: 12, x: 0, y: 0)
-            .shadow(color: isSelected ? accentColor.opacity(0.5) : .clear, radius: 4, x: 0, y: 0)
+            .foregroundStyle(isSelected ? Color.white : .white.opacity(0.55))
+            .shadow(color: isSelected ? accentColor : .clear, radius: 16, x: 0, y: 0)
+            .shadow(color: isSelected ? accentColor.opacity(0.6) : .clear, radius: 6, x: 0, y: 0)
             .padding(.vertical, 8)
             .padding(.horizontal, 10)
-            .scaleEffect(magnifyScale)
-            .animation(.bouncy(duration: 0.3), value: magnifyScale)
+            .scaleEffect(finalScale)
+            .animation(.bouncy(duration: 0.25), value: finalScale)
         }
         .frame(maxWidth: .infinity)
         .buttonStyle(.plain)
@@ -286,13 +440,27 @@ private struct BottomPillMenu: View {
                 )
             }
         )
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    if pressedTab != tab {
+                        pressedTab = tab
+                        withAnimation(.bouncy(duration: 0.15)) {
+                            blobScales[tab] = 0.95
+                        }
+                    }
+                }
+                .onEnded { _ in
+                    pressedTab = nil
+                    withAnimation(.bouncy(duration: 0.4)) {
+                        blobScales[tab] = 1.0
+                    }
+                    wobbleAmplitude = min(wobbleAmplitude + 0.02, 0.06)
+                }
+        )
 
         if isSelected {
-            base
-                .refractiveGlass(tint: accentColor, interactive: true, in: .capsule)
-        } else {
-            base
-                .glassEffect(.identity, in: .capsule)
+            EmptyView()
         }
     }
 
@@ -300,13 +468,14 @@ private struct BottomPillMenu: View {
         DragGesture(minimumDistance: 0, coordinateSpace: .named("pill"))
             .onChanged { value in
                 if !isDragging {
-                    withAnimation(.bouncy(duration: 0.25)) {
+                    withAnimation(.bouncy(duration: 0.2)) {
                         isDragging = true
                     }
+                    wobbleAmplitude = 0.03
                 }
                 dragLocation = value.location
                 if let nearest = nearestTab(to: value.location), hoverTab != nearest {
-                    withAnimation(.bouncy(duration: 0.35)) {
+                    withAnimation(.bouncy(duration: 0.3)) {
                         hoverTab = nearest
                     }
                 }
@@ -316,8 +485,9 @@ private struct BottomPillMenu: View {
                     withAnimation(.bouncy(duration: 0.4)) {
                         selectedTab = hoverTab
                     }
+                    wobbleAmplitude = 0.05
                 }
-                withAnimation(.bouncy(duration: 0.35)) {
+                withAnimation(.bouncy(duration: 0.3)) {
                     isDragging = false
                 }
                 dragLocation = nil
@@ -330,10 +500,160 @@ private struct BottomPillMenu: View {
     }
 }
 
+private struct ContainerFrameKey: PreferenceKey {
+    static let defaultValue: CGRect = .zero
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
+    }
+}
+
 private struct TabFrameKey: PreferenceKey {
     static let defaultValue: [BottomTab: CGRect] = [:]
     static func reduce(value: inout [BottomTab: CGRect], nextValue: () -> [BottomTab: CGRect]) {
         value.merge(nextValue(), uniquingKeysWith: { $1 })
+    }
+}
+
+private struct AnimatedCausticBackdrop: View {
+    let time: CGFloat
+    let accentColor: Color
+    
+    var body: some View {
+        let slow = time * 0.08
+        let mid = time * 0.12
+        let fast = time * 0.18
+        
+        Canvas { context, size in
+            let w = size.width
+            let h = size.height
+            
+            let caustic1Center = CGPoint(
+                x: w * (0.2 + 0.15 * sin(slow)),
+                y: h * (0.3 + 0.2 * cos(slow * 1.1))
+            )
+            let caustic2Center = CGPoint(
+                x: w * (0.75 + 0.12 * cos(mid)),
+                y: h * (0.6 + 0.15 * sin(mid * 0.9))
+            )
+            let caustic3Center = CGPoint(
+                x: w * (0.5 + 0.1 * sin(fast)),
+                y: h * (0.5 + 0.1 * cos(fast * 1.2))
+            )
+            
+            context.drawLayer { ctx in
+                let gradient1 = Gradient(colors: [
+                    Color.white.opacity(0.25),
+                    Color.white.opacity(0.08),
+                    Color.clear
+                ])
+                ctx.fill(
+                    Path(ellipseIn: CGRect(
+                        x: caustic1Center.x - 80,
+                        y: caustic1Center.y - 40,
+                        width: 160,
+                        height: 80
+                    )),
+                    with: .radialGradient(
+                        gradient1,
+                        center: caustic1Center,
+                        startRadius: 0,
+                        endRadius: 90
+                    )
+                )
+            }
+            
+            context.drawLayer { ctx in
+                let gradient2 = Gradient(colors: [
+                    accentColor.opacity(0.3),
+                    accentColor.opacity(0.1),
+                    Color.clear
+                ])
+                ctx.fill(
+                    Path(ellipseIn: CGRect(
+                        x: caustic2Center.x - 70,
+                        y: caustic2Center.y - 35,
+                        width: 140,
+                        height: 70
+                    )),
+                    with: .radialGradient(
+                        gradient2,
+                        center: caustic2Center,
+                        startRadius: 0,
+                        endRadius: 80
+                    )
+                )
+            }
+            
+            context.drawLayer { ctx in
+                let gradient3 = Gradient(colors: [
+                    Color.white.opacity(0.15),
+                    Color.clear
+                ])
+                ctx.fill(
+                    Path(ellipseIn: CGRect(
+                        x: caustic3Center.x - 50,
+                        y: caustic3Center.y - 25,
+                        width: 100,
+                        height: 50
+                    )),
+                    with: .radialGradient(
+                        gradient3,
+                        center: caustic3Center,
+                        startRadius: 0,
+                        endRadius: 60
+                    )
+                )
+            }
+            
+            for i in 0..<5 {
+                let phase = time * 0.15 + Double(i) * 0.7
+                let sparkleX = w * (0.1 + 0.8 * (Double(i) / 5.0) + 0.05 * sin(phase))
+                let sparkleY = h * (0.3 + 0.4 * cos(phase * 0.8 + Double(i)))
+                let sparkleAlpha = 0.3 + 0.4 * (0.5 + 0.5 * sin(phase * 2))
+                
+                context.drawLayer { ctx in
+                    ctx.fill(
+                        Path(ellipseIn: CGRect(x: sparkleX - 3, y: sparkleY - 3, width: 6, height: 6)),
+                        with: .color(Color.white.opacity(sparkleAlpha))
+                    )
+                }
+            }
+        }
+        .blendMode(.plusLighter)
+    }
+}
+
+// Subtle moving caustics so refraction reads against a flat background.
+private struct CausticPillBackdrop: View {
+    var body: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { timeline in
+            let t = timeline.date.timeIntervalSinceReferenceDate
+            let slow = t * 0.12
+            let mid = t * 0.18
+
+            ZStack {
+                RadialGradient(
+                    colors: [
+                        Color.white.opacity(0.18),
+                        Color.clear
+                    ],
+                    center: UnitPoint(x: 0.2 + 0.12 * sin(slow), y: 0.3 + 0.1 * cos(slow)),
+                    startRadius: 0,
+                    endRadius: 140
+                )
+                RadialGradient(
+                    colors: [
+                        Color.cyan.opacity(0.2),
+                        Color.clear
+                    ],
+                    center: UnitPoint(x: 0.8 + 0.1 * cos(mid), y: 0.7 + 0.08 * sin(mid)),
+                    startRadius: 0,
+                    endRadius: 120
+                )
+            }
+            .blendMode(.plusLighter)
+            .opacity(0.5)
+        }
     }
 }
 
@@ -473,4 +793,8 @@ private final class MotionProvider: ObservableObject {
     private func clamp(_ value: Double) -> CGFloat {
         CGFloat(min(max(value, -1.0), 1.0))
     }
+}
+#Preview("ContentView") {
+    ContentView()
+        .environment(FastingStore())
 }

--- a/GlassticPackage/Sources/GlassticFeature/Shaders/LiquidGlass.metal
+++ b/GlassticPackage/Sources/GlassticFeature/Shaders/LiquidGlass.metal
@@ -2,6 +2,54 @@
 #include <SwiftUI/SwiftUI_Metal.h>
 using namespace metal;
 
+// ───────────────────────────────────────────────────────────────────────────────
+// MARK: - Utility Functions
+// ───────────────────────────────────────────────────────────────────────────────
+
+// Simplex-like 2D noise for caustic patterns
+float hash21(float2 p) {
+    float3 p3 = fract(float3(p.xyx) * 0.1031);
+    p3 += dot(p3, p3.yzx + 33.33);
+    return fract((p3.x + p3.y) * p3.z);
+}
+
+float noise2D(float2 p) {
+    float2 i = floor(p);
+    float2 f = fract(p);
+    float2 u = f * f * (3.0 - 2.0 * f);
+    
+    float a = hash21(i);
+    float b = hash21(i + float2(1.0, 0.0));
+    float c = hash21(i + float2(0.0, 1.0));
+    float d = hash21(i + float2(1.0, 1.0));
+    
+    return mix(mix(a, b, u.x), mix(c, d, u.x), u.y);
+}
+
+// Fractal brownian motion for organic caustics
+float fbm(float2 p, int octaves) {
+    float value = 0.0;
+    float amplitude = 0.5;
+    float frequency = 1.0;
+    
+    for (int i = 0; i < octaves; i++) {
+        value += amplitude * noise2D(p * frequency);
+        amplitude *= 0.5;
+        frequency *= 2.0;
+    }
+    return value;
+}
+
+// Smooth metaball distance function
+float metaballSDF(float2 p, float2 center, float radius) {
+    float d = length(p - center);
+    return radius / (d * d + 0.001);
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+// MARK: - Legacy Shader (unchanged for compatibility)
+// ───────────────────────────────────────────────────────────────────────────────
+
 // Refraction with shadow and rim lighting.
 [[stitchable]] half4 liquidGlassAdvanced(
     float2 position,
@@ -58,5 +106,462 @@ using namespace metal;
         result.rgb += edgeFade * rimBias * highlightColor;
     }
 
+    return result;
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+// MARK: - Gel Glass Shader (Pure Liquid Glass with Chromatic Aberration)
+// ───────────────────────────────────────────────────────────────────────────────
+
+[[stitchable]] half4 gelGlass(
+    float2 position,
+    SwiftUI::Layer layer,
+    float4 bounds,
+    float2 glassCenter,       // Normalized center (0.5, 0.5 for center)
+    float glassRadius,        // Normalized radius (0-1, where 1 fills container)
+    float refraction,         // Refraction strength (0.1-0.3 typical)
+    float chromaticSpread,    // Chromatic aberration spread (0.02-0.08)
+    float glassThickness,     // Simulated thickness for depth (0.3-0.8)
+    float causticIntensity,   // Caustic light pattern intensity (0.1-0.5)
+    float time                // Animation time for caustics
+) {
+    float2 size = bounds.zw;
+    if (size.x <= 0.0 || size.y <= 0.0) {
+        return layer.sample(position);
+    }
+
+    float2 localPos = position - bounds.xy;
+    float2 uv = localPos / size;
+    
+    // Aspect ratio correction for proper circular/elliptical shapes
+    float aspectRatio = size.x / size.y;
+    float2 aspectCorrectedUV = float2(uv.x, uv.y * aspectRatio);
+    float2 aspectCorrectedCenter = float2(glassCenter.x, glassCenter.y * aspectRatio);
+    
+    float2 toCenter = aspectCorrectedUV - aspectCorrectedCenter;
+    float dist = length(toCenter);
+    float normalizedDist = dist / glassRadius;
+    
+    // Outside the glass - return original with subtle shadow
+    if (normalizedDist > 1.0) {
+        half4 result = layer.sample(position);
+        
+        // Soft shadow falloff outside glass
+        float shadowFalloff = smoothstep(1.3, 1.0, normalizedDist);
+        result.rgb *= (1.0 - shadowFalloff * 0.1);
+        
+        return result;
+    }
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Inside the glass - apply full liquid glass treatment
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    // Gel-like refraction: stronger at edges, creating thick glass appearance
+    float edgeFactor = pow(normalizedDist, 2.0);
+    float centerFactor = 1.0 - normalizedDist * normalizedDist;
+    
+    // Gel distortion with thickness simulation
+    float gelDistortion = centerFactor * refraction * glassThickness;
+    float2 refractionOffset = toCenter * gelDistortion;
+    
+    // Calculate refracted positions for chromatic aberration
+    // Red bends least, blue bends most (like real glass dispersion)
+    float2 redOffset = refractionOffset * (1.0 - chromaticSpread);
+    float2 greenOffset = refractionOffset;
+    float2 blueOffset = refractionOffset * (1.0 + chromaticSpread * 1.5);
+    
+    // Sample each color channel at slightly different positions
+    float2 redPos = position + redOffset * size;
+    float2 greenPos = position + greenOffset * size;
+    float2 bluePos = position + blueOffset * size;
+    
+    half redChannel = layer.sample(redPos).r;
+    half greenChannel = layer.sample(greenPos).g;
+    half blueChannel = layer.sample(bluePos).b;
+    half alphaChannel = layer.sample(position).a;
+    
+    half4 result = half4(redChannel, greenChannel, blueChannel, alphaChannel);
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Caustic light patterns (animated water-like light refraction)
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    float2 causticUV = uv * 6.0 + float2(time * 0.3, time * 0.2);
+    float caustic1 = fbm(causticUV, 3);
+    float caustic2 = fbm(causticUV * 1.5 + float2(2.3, 1.7), 3);
+    float causticPattern = caustic1 * caustic2;
+    
+    // Focus caustics more in the center, fade at edges
+    float causticMask = centerFactor * centerFactor;
+    float causticValue = causticPattern * causticMask * causticIntensity;
+    
+    // Add warm caustic highlights (slightly golden)
+    half3 causticColor = half3(1.15, 1.1, 1.0);
+    result.rgb += causticValue * causticColor;
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Rim lighting and specular highlights
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    // Primary light from top-left
+    float2 lightDir1 = normalize(float2(-0.6, -0.8));
+    float rimLight1 = pow(max(0.0, dot(normalize(toCenter), lightDir1)), 4.0);
+    
+    // Secondary fill light from bottom-right
+    float2 lightDir2 = normalize(float2(0.4, 0.6));
+    float rimLight2 = pow(max(0.0, dot(normalize(toCenter), lightDir2)), 6.0) * 0.3;
+    
+    // Edge highlight (fresnel-like effect)
+    float edgeHighlight = smoothstep(0.7, 1.0, normalizedDist);
+    float rimTotal = (rimLight1 + rimLight2) * edgeHighlight;
+    
+    // Cool-tinted rim light
+    half3 rimColor = half3(0.9, 0.95, 1.1);
+    result.rgb += rimTotal * rimColor * 0.4;
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Glass depth: subtle darkening at thick center, brighter at thin edges
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    float depthDarkening = centerFactor * glassThickness * 0.1;
+    result.rgb *= (1.0 - depthDarkening);
+    
+    // Inner glow at the very edge (subsurface scattering simulation)
+    float innerGlow = smoothstep(0.85, 0.98, normalizedDist) * (1.0 - normalizedDist);
+    result.rgb += innerGlow * half3(0.2, 0.3, 0.35);
+    
+    return result;
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+// MARK: - Metaball Blob Shader (Gooey Merging Effect)
+// ───────────────────────────────────────────────────────────────────────────────
+
+[[stitchable]] half4 metaballBlob(
+    float2 position,
+    SwiftUI::Layer layer,
+    float4 bounds,
+    float4 blob1,             // x, y = center, z = radius, w = intensity
+    float4 blob2,             // Second blob (can be zero if single)
+    float threshold,          // Metaball threshold (0.5-2.0)
+    float smoothness,         // Edge smoothness (0.1-0.5)
+    float wobbleAmount,       // Wobble deformation amount
+    float wobblePhase         // Wobble animation phase
+) {
+    float2 size = bounds.zw;
+    if (size.x <= 0.0 || size.y <= 0.0) {
+        return layer.sample(position);
+    }
+
+    float2 localPos = position - bounds.xy;
+    float2 uv = localPos / size;
+    
+    // Apply wobble deformation to UV
+    float2 wobbleOffset = float2(
+        sin(uv.y * 8.0 + wobblePhase) * wobbleAmount,
+        cos(uv.x * 8.0 + wobblePhase * 1.3) * wobbleAmount
+    );
+    float2 deformedUV = uv + wobbleOffset;
+    
+    // Calculate metaball field
+    float field = 0.0;
+    
+    // Blob 1
+    if (blob1.w > 0.0) {
+        float2 center1 = blob1.xy;
+        float radius1 = blob1.z;
+        field += metaballSDF(deformedUV, center1, radius1) * blob1.w;
+    }
+    
+    // Blob 2
+    if (blob2.w > 0.0) {
+        float2 center2 = blob2.xy;
+        float radius2 = blob2.z;
+        field += metaballSDF(deformedUV, center2, radius2) * blob2.w;
+    }
+    
+    // Smooth threshold for gooey edge
+    float edge = smoothstep(threshold - smoothness, threshold + smoothness, field);
+    
+    half4 baseColor = layer.sample(position);
+    
+    // Apply metaball mask with soft edge
+    if (edge < 0.01) {
+        return baseColor;
+    }
+    
+    // Inside metaball - apply gel refraction
+    float2 fieldGradient = float2(
+        metaballSDF(deformedUV + float2(0.001, 0.0), blob1.xy, blob1.z) -
+        metaballSDF(deformedUV - float2(0.001, 0.0), blob1.xy, blob1.z),
+        metaballSDF(deformedUV + float2(0.0, 0.001), blob1.xy, blob1.z) -
+        metaballSDF(deformedUV - float2(0.0, 0.001), blob1.xy, blob1.z)
+    );
+    
+    float2 refractOffset = normalize(fieldGradient + 0.001) * 0.02 * edge;
+    half4 refracted = layer.sample(position + refractOffset * size);
+    
+    // Blend with edge glow
+    half3 glowColor = half3(0.3, 0.8, 1.0);
+    float edgeGlow = smoothstep(0.3, 0.7, edge) * (1.0 - smoothstep(0.7, 1.0, edge));
+    
+    half4 result = refracted;
+    result.rgb = mix(result.rgb, glowColor, edgeGlow * 0.3);
+    result.a = max(result.a, half(edge));
+    
+    return result;
+}
+
+// ───────────────────────────────────────────────────────────────────────────────
+// MARK: - Pill Glass Shader (Specialized for pill/capsule shapes)
+// ───────────────────────────────────────────────────────────────────────────────
+
+[[stitchable]] half4 pillGelGlass(
+    float2 position,
+    SwiftUI::Layer layer,
+    float4 bounds,
+    float cornerRadius,       // Normalized corner radius for pill shape
+    float refraction,         // Refraction strength
+    float chromaticSpread,    // Chromatic aberration
+    float glassThickness,     // Depth simulation
+    float causticIntensity,   // Caustic pattern strength
+    float time,               // Animation time
+    float wobbleAmount,       // Gel wobble deformation
+    float wobbleFreq          // Wobble frequency
+) {
+    float2 size = bounds.zw;
+    if (size.x <= 0.0 || size.y <= 0.0) {
+        return layer.sample(position);
+    }
+
+    float2 localPos = position - bounds.xy;
+    float2 uv = localPos / size;
+    float2 centeredUV = uv - 0.5;
+    
+    // Calculate distance to pill shape (rounded rectangle / capsule)
+    float2 absUV = abs(centeredUV);
+    float aspect = size.x / size.y;
+    
+    // Pill SDF: capsule shape
+    float pillHalfWidth = 0.5 - cornerRadius / aspect;
+    float pillHalfHeight = 0.5 - cornerRadius;
+    
+    float2 q = absUV - float2(pillHalfWidth, pillHalfHeight);
+    q = max(q, 0.0);
+    float distToEdge = length(q) - cornerRadius;
+    
+    // Normalize distance (0 at center, 1 at edge)
+    float normalizedDist = saturate(distToEdge / cornerRadius + 1.0);
+    
+    // Outside the pill
+    if (distToEdge > 0.02) {
+        half4 result = layer.sample(position);
+        // Soft outer shadow
+        float shadowFalloff = smoothstep(0.1, 0.0, distToEdge);
+        result.rgb *= (1.0 - shadowFalloff * 0.15);
+        return result;
+    }
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Gel wobble deformation
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    float wobble1 = sin(uv.x * wobbleFreq + time * 2.0) * wobbleAmount;
+    float wobble2 = cos(uv.y * wobbleFreq * 1.3 + time * 1.7) * wobbleAmount;
+    float2 wobbleOffset = float2(wobble1, wobble2) * (1.0 - normalizedDist);
+    
+    float2 deformedUV = uv + wobbleOffset;
+    float2 deformedPos = position + wobbleOffset * size;
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Gel refraction with chromatic aberration
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    float centerFactor = 1.0 - normalizedDist * normalizedDist;
+    float edgeFactor = normalizedDist;
+    
+    // Direction-aware refraction (bends toward center)
+    float2 refractionDir = -normalize(centeredUV + 0.001);
+    float gelDistortion = centerFactor * refraction * glassThickness;
+    float2 refractionOffset = refractionDir * gelDistortion * 0.5 + wobbleOffset;
+    
+    // Chromatic aberration channels
+    float2 redPos = deformedPos + refractionOffset * size * (1.0 - chromaticSpread);
+    float2 greenPos = deformedPos + refractionOffset * size;
+    float2 bluePos = deformedPos + refractionOffset * size * (1.0 + chromaticSpread * 1.8);
+    
+    half redChannel = layer.sample(redPos).r;
+    half greenChannel = layer.sample(greenPos).g;
+    half blueChannel = layer.sample(bluePos).b;
+    
+    half4 result = half4(redChannel, greenChannel, blueChannel, 1.0);
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Animated caustics
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    float2 causticUV = deformedUV * 5.0;
+    float caustic1 = fbm(causticUV + float2(time * 0.4, time * 0.25), 3);
+    float caustic2 = fbm(causticUV * 1.4 + float2(time * -0.3, time * 0.35), 3);
+    float causticPattern = caustic1 * caustic2 * 2.0;
+    
+    float causticMask = centerFactor;
+    float causticValue = causticPattern * causticMask * causticIntensity;
+    
+    half3 causticColor = half3(1.2, 1.15, 1.05);
+    result.rgb += causticValue * causticColor;
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Multi-directional rim lighting
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    // Top-left primary light
+    float2 lightDir1 = normalize(float2(-0.5, -0.7));
+    float rim1 = pow(max(0.0, dot(normalize(centeredUV), lightDir1)), 3.0);
+    
+    // Bottom-right fill
+    float2 lightDir2 = normalize(float2(0.6, 0.5));
+    float rim2 = pow(max(0.0, dot(normalize(centeredUV), lightDir2)), 4.0) * 0.4;
+    
+    // Top specular
+    float topSpec = smoothstep(0.0, -0.3, centeredUV.y) * smoothstep(0.8, 1.0, normalizedDist);
+    
+    float edgeMask = smoothstep(0.5, 1.0, normalizedDist);
+    float rimTotal = (rim1 + rim2) * edgeMask + topSpec * 0.5;
+    
+    half3 rimColor = half3(1.0, 1.0, 1.1);
+    result.rgb += rimTotal * rimColor * 0.35;
+    
+    // ─────────────────────────────────────────────────────────────────────────
+    // Glass depth and inner glow
+    // ─────────────────────────────────────────────────────────────────────────
+    
+    float depthFactor = centerFactor * glassThickness * 0.08;
+    result.rgb *= (1.0 - depthFactor);
+    
+    float innerGlow = smoothstep(0.7, 0.95, normalizedDist) * centerFactor;
+    result.rgb += innerGlow * half3(0.15, 0.25, 0.3);
+    
+    float edgeLine = smoothstep(0.02, 0.0, abs(distToEdge)) * 0.15;
+    result.rgb += edgeLine * half3(1.0, 1.0, 1.0);
+    
+    return result;
+}
+
+[[stitchable]] half4 clearLiquidGlass(
+    float2 position,
+    SwiftUI::Layer layer,
+    float4 bounds,
+    float cornerRadius,
+    float refraction,
+    float chromaticSpread,
+    float edgeHighlight,
+    float causticIntensity,
+    float time,
+    float wobbleAmount,
+    float wobbleFreq
+) {
+    float2 size = bounds.zw;
+    if (size.x <= 0.0 || size.y <= 0.0) {
+        return layer.sample(position);
+    }
+
+    float2 localPos = position - bounds.xy;
+    float2 uv = localPos / size;
+    float2 centeredUV = uv - 0.5;
+    
+    float2 absUV = abs(centeredUV);
+    float aspect = size.x / size.y;
+    
+    float pillHalfWidth = 0.5 - cornerRadius / aspect;
+    float pillHalfHeight = 0.5 - cornerRadius;
+    
+    float2 q = absUV - float2(pillHalfWidth, pillHalfHeight);
+    q = max(q, 0.0);
+    float distToEdge = length(q) - cornerRadius;
+    
+    float normalizedDist = saturate(1.0 - distToEdge / 0.15);
+    
+    if (distToEdge > 0.03) {
+        return layer.sample(position);
+    }
+    
+    float wobble1 = sin(uv.x * wobbleFreq * 2.0 + time * 3.0) * wobbleAmount;
+    float wobble2 = cos(uv.y * wobbleFreq * 2.5 + time * 2.5) * wobbleAmount;
+    float wobble3 = sin((uv.x + uv.y) * wobbleFreq * 1.5 + time * 2.0) * wobbleAmount * 0.5;
+    float2 wobbleOffset = float2(wobble1 + wobble3, wobble2 + wobble3) * normalizedDist;
+    
+    float2 deformedPos = position + wobbleOffset * size;
+    
+    float edgeFalloff = smoothstep(0.0, 0.5, normalizedDist);
+    float centerBulge = pow(normalizedDist, 0.7);
+    
+    float2 normal = normalize(centeredUV + 0.0001);
+    float bendStrength = refraction * centerBulge * (1.0 + 0.3 * sin(time * 2.0));
+    
+    float edgeBend = smoothstep(0.3, 1.0, normalizedDist) * 0.5;
+    float2 refractionDir = -normal * bendStrength + normal * edgeBend * refraction * 0.3;
+    
+    float2 baseOffset = refractionDir * size + wobbleOffset * size;
+    
+    float2 redPos = deformedPos + baseOffset * (1.0 - chromaticSpread * 1.2);
+    float2 greenPos = deformedPos + baseOffset;
+    float2 bluePos = deformedPos + baseOffset * (1.0 + chromaticSpread * 2.0);
+    
+    half redChannel = layer.sample(redPos).r;
+    half greenChannel = layer.sample(greenPos).g;
+    half blueChannel = layer.sample(bluePos).b;
+    half alphaChannel = layer.sample(position).a;
+    
+    half4 result = half4(redChannel, greenChannel, blueChannel, alphaChannel);
+    
+    float2 causticUV = uv * 8.0;
+    float caustic1 = fbm(causticUV + float2(time * 0.5, time * 0.3), 4);
+    float caustic2 = fbm(causticUV * 1.3 + float2(time * -0.4, time * 0.4), 4);
+    float caustic3 = fbm(causticUV * 0.7 + float2(time * 0.2, time * -0.3), 3);
+    float causticPattern = caustic1 * caustic2 + caustic3 * 0.3;
+    causticPattern = pow(causticPattern, 1.5) * 2.5;
+    
+    float causticMask = centerBulge * (0.7 + 0.3 * sin(time + uv.x * 4.0));
+    float causticValue = causticPattern * causticMask * causticIntensity;
+    
+    half3 causticColor = half3(1.3, 1.25, 1.15);
+    result.rgb += causticValue * causticColor;
+    
+    float sparkle = pow(noise2D(uv * 30.0 + time * 2.0), 8.0) * normalizedDist;
+    result.rgb += sparkle * 0.4 * half3(1.0, 1.0, 1.1);
+    
+    float2 lightDir1 = normalize(float2(-0.5, -0.8));
+    float rim1 = pow(max(0.0, dot(normal, lightDir1)), 2.5);
+    
+    float2 lightDir2 = normalize(float2(0.7, 0.3));
+    float rim2 = pow(max(0.0, dot(normal, lightDir2)), 3.5) * 0.5;
+    
+    float2 lightDir3 = normalize(float2(0.0, -1.0));
+    float rim3 = pow(max(0.0, dot(normal, lightDir3)), 4.0) * 0.3;
+    
+    float edgeMask = smoothstep(0.3, 0.95, normalizedDist);
+    float rimTotal = (rim1 + rim2 + rim3) * edgeMask * edgeHighlight;
+    
+    half3 rimColor = half3(1.0, 1.0, 1.15);
+    result.rgb += rimTotal * rimColor * 0.6;
+    
+    float topHighlight = smoothstep(0.1, -0.2, centeredUV.y) * smoothstep(0.6, 0.9, normalizedDist);
+    result.rgb += topHighlight * half3(0.25, 0.25, 0.3) * edgeHighlight;
+    
+    float bottomReflection = smoothstep(-0.1, 0.15, centeredUV.y) * smoothstep(0.7, 0.95, normalizedDist) * 0.15;
+    result.rgb += bottomReflection * half3(0.8, 0.85, 1.0);
+    
+    float innerLight = (1.0 - normalizedDist) * 0.08;
+    result.rgb += innerLight * half3(0.9, 0.95, 1.0);
+    
+    float edgeLine = smoothstep(0.025, 0.0, abs(distToEdge));
+    float edgeGlow = smoothstep(0.06, 0.0, abs(distToEdge)) * 0.4;
+    result.rgb += (edgeLine * 0.35 + edgeGlow) * half3(1.0, 1.0, 1.1);
+    
+    float softVignette = 1.0 - pow(1.0 - normalizedDist, 3.0) * 0.1;
+    result.rgb *= softVignette;
+    
     return result;
 }

--- a/GlassticPackage/Sources/GlassticFeature/Utilities/GelPhysics.swift
+++ b/GlassticPackage/Sources/GlassticFeature/Utilities/GelPhysics.swift
@@ -1,0 +1,375 @@
+import SwiftUI
+
+@MainActor
+@Observable
+final class GelPhysicsEngine {
+    struct Configuration: Sendable {
+        var viscosity: CGFloat = 0.7
+        var bounciness: CGFloat = 0.6
+        var stiffness: CGFloat = 180.0
+        var damping: CGFloat = 0.7
+        var maxStretch: CGFloat = 100.0
+        var wobbleFrequency: CGFloat = 8.0
+        var wobbleDecay: CGFloat = 0.92
+        
+        static let `default` = Configuration()
+        
+        static let viscousGel = Configuration(
+            viscosity: 0.85,
+            bounciness: 0.4,
+            stiffness: 120.0,
+            damping: 0.8
+        )
+        
+        static let bouncyGel = Configuration(
+            viscosity: 0.5,
+            bounciness: 0.8,
+            stiffness: 250.0,
+            damping: 0.55
+        )
+    }
+    
+    private(set) var offset: CGPoint = .zero
+    private(set) var velocity: CGPoint = .zero
+    private(set) var wobblePhase: CGFloat = 0
+    private(set) var wobbleAmplitude: CGFloat = 0
+    private(set) var isDragging: Bool = false
+    var restPosition: CGPoint = .zero
+    var config: Configuration
+    
+    private var displayLink: CADisplayLink?
+    private var lastUpdateTime: CFTimeInterval = 0
+    
+    init(config: Configuration = .default) {
+        self.config = config
+    }
+    
+    func beginDrag(at point: CGPoint) {
+        isDragging = true
+        wobbleAmplitude = min(wobbleAmplitude + 0.02, 0.05)
+        startSimulation()
+    }
+    
+    func updateDrag(to point: CGPoint, delta: CGPoint) {
+        guard isDragging else { return }
+        
+        let stretch = hypot(point.x - restPosition.x, point.y - restPosition.y)
+        let stretchFactor = min(stretch / config.maxStretch, 1.0)
+        let resistance = config.viscosity + (1.0 - config.viscosity) * stretchFactor * stretchFactor
+        
+        let dampedDelta = CGPoint(
+            x: delta.x * (1.0 - resistance * 0.8),
+            y: delta.y * (1.0 - resistance * 0.8)
+        )
+        
+        var newOffset = CGPoint(
+            x: offset.x + dampedDelta.x,
+            y: offset.y + dampedDelta.y
+        )
+        
+        if abs(newOffset.x) > config.maxStretch {
+            let sign = newOffset.x > 0 ? 1.0 : -1.0
+            let excess = abs(newOffset.x) - config.maxStretch
+            newOffset.x = sign * (config.maxStretch + log(1 + excess) * 10)
+        }
+        if abs(newOffset.y) > config.maxStretch {
+            let sign = newOffset.y > 0 ? 1.0 : -1.0
+            let excess = abs(newOffset.y) - config.maxStretch
+            newOffset.y = sign * (config.maxStretch + log(1 + excess) * 10)
+        }
+        
+        velocity = CGPoint(
+            x: dampedDelta.x / 0.016,
+            y: dampedDelta.y / 0.016
+        )
+        
+        offset = newOffset
+        
+        let speed = hypot(delta.x, delta.y)
+        wobbleAmplitude = min(wobbleAmplitude + speed * 0.001, 0.06)
+    }
+    
+    func endDrag() {
+        isDragging = false
+        let releaseSpeed = hypot(velocity.x, velocity.y)
+        wobbleAmplitude = min(wobbleAmplitude + releaseSpeed * 0.0002, 0.08)
+        velocity = CGPoint(
+            x: velocity.x * config.bounciness,
+            y: velocity.y * config.bounciness
+        )
+    }
+    
+    func triggerWobble(intensity: CGFloat = 1.0) {
+        wobbleAmplitude = min(wobbleAmplitude + 0.04 * intensity, 0.08)
+        startSimulation()
+    }
+    
+    func snapTo(offset newOffset: CGPoint) {
+        guard !isDragging else { return }
+        
+        let impulse = CGPoint(
+            x: newOffset.x - offset.x,
+            y: newOffset.y - offset.y
+        )
+        
+        offset = newOffset
+        velocity = CGPoint(x: impulse.x * 2.0, y: impulse.y * 2.0)
+        wobbleAmplitude = min(0.05, wobbleAmplitude + 0.03)
+        startSimulation()
+    }
+    
+    func reset() {
+        offset = .zero
+        velocity = .zero
+        wobbleAmplitude = 0
+        wobblePhase = 0
+        isDragging = false
+        stopSimulation()
+    }
+    
+    private func startSimulation() {
+        guard displayLink == nil else { return }
+        let link = CADisplayLink(target: SimulationTarget(engine: self), selector: #selector(SimulationTarget.tick))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+        lastUpdateTime = CACurrentMediaTime()
+    }
+    
+    private func stopSimulation() {
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+    
+    fileprivate func update() {
+        let currentTime = CACurrentMediaTime()
+        let dt = min(currentTime - lastUpdateTime, 1.0 / 30.0)
+        lastUpdateTime = currentTime
+        
+        wobblePhase += config.wobbleFrequency * dt
+        if wobblePhase > .pi * 2 { wobblePhase -= .pi * 2 }
+        
+        wobbleAmplitude *= pow(config.wobbleDecay, dt * 60)
+        if wobbleAmplitude < 0.001 { wobbleAmplitude = 0 }
+        
+        if isDragging { return }
+        
+        let displacement = CGPoint(
+            x: offset.x - restPosition.x,
+            y: offset.y - restPosition.y
+        )
+        
+        let springForce = CGPoint(
+            x: -config.stiffness * displacement.x,
+            y: -config.stiffness * displacement.y
+        )
+        
+        let dampingForce = CGPoint(
+            x: -config.damping * config.stiffness * 2 * velocity.x,
+            y: -config.damping * config.stiffness * 2 * velocity.y
+        )
+        
+        let acceleration = CGPoint(
+            x: springForce.x + dampingForce.x,
+            y: springForce.y + dampingForce.y
+        )
+        
+        velocity = CGPoint(
+            x: velocity.x + acceleration.x * dt,
+            y: velocity.y + acceleration.y * dt
+        )
+        
+        offset = CGPoint(
+            x: offset.x + velocity.x * dt,
+            y: offset.y + velocity.y * dt
+        )
+        
+        let speed = hypot(velocity.x, velocity.y)
+        let distance = hypot(displacement.x, displacement.y)
+        
+        if speed < 0.5 && distance < 0.5 && wobbleAmplitude < 0.001 {
+            offset = restPosition
+            velocity = .zero
+            stopSimulation()
+        }
+    }
+}
+
+private class SimulationTarget: @unchecked Sendable {
+    weak var engine: GelPhysicsEngine?
+    
+    init(engine: GelPhysicsEngine) {
+        self.engine = engine
+    }
+    
+    @objc func tick() {
+        Task { @MainActor [weak self] in
+            self?.engine?.update()
+        }
+    }
+}
+
+struct GelDragGesture: Gesture {
+    let engine: GelPhysicsEngine
+    let onChanged: ((CGPoint) -> Void)?
+    let onEnded: (() -> Void)?
+    
+    init(engine: GelPhysicsEngine, onChanged: ((CGPoint) -> Void)? = nil, onEnded: (() -> Void)? = nil) {
+        self.engine = engine
+        self.onChanged = onChanged
+        self.onEnded = onEnded
+    }
+    
+    var body: some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                if !engine.isDragging {
+                    engine.beginDrag(at: value.startLocation)
+                }
+                engine.updateDrag(
+                    to: value.location,
+                    delta: CGPoint(
+                        x: value.translation.width - engine.offset.x,
+                        y: value.translation.height - engine.offset.y
+                    )
+                )
+                onChanged?(engine.offset)
+            }
+            .onEnded { _ in
+                engine.endDrag()
+                onEnded?()
+            }
+    }
+}
+
+extension View {
+    func gelPhysics(_ engine: GelPhysicsEngine) -> some View {
+        self
+            .offset(x: engine.offset.x, y: engine.offset.y)
+            .scaleEffect(1.0 + engine.wobbleAmplitude * 0.5)
+    }
+}
+
+@MainActor
+@Observable
+final class GelSelectionTracker<Item: Hashable & Equatable> {
+    private(set) var selectedItem: Item?
+    private(set) var previousItem: Item?
+    private(set) var animatedPosition: CGFloat = 0
+    private(set) var targetPosition: CGFloat = 0
+    private var velocity: CGFloat = 0
+    private(set) var wobblePhase: CGFloat = 0
+    private(set) var wobbleAmplitude: CGFloat = 0
+    private var itemFrames: [Item: CGRect] = [:]
+    private var containerBounds: CGRect = .zero
+    var stiffness: CGFloat = 200
+    var damping: CGFloat = 0.7
+    
+    private var displayLink: CADisplayLink?
+    private var lastUpdateTime: CFTimeInterval = 0
+    
+    init(initialSelection: Item? = nil) {
+        self.selectedItem = initialSelection
+    }
+    
+    func updateFrame(_ frame: CGRect, for item: Item, in container: CGRect) {
+        itemFrames[item] = frame
+        containerBounds = container
+        
+        if item == selectedItem {
+            let center = frame.midX
+            let normalizedPos = (center - container.minX) / container.width
+            
+            if abs(targetPosition - normalizedPos) > 0.001 {
+                targetPosition = normalizedPos
+                if displayLink == nil { animatedPosition = normalizedPos }
+            }
+        }
+    }
+    
+    func select(_ item: Item) {
+        guard item != selectedItem else { return }
+        
+        previousItem = selectedItem
+        selectedItem = item
+        
+        if let frame = itemFrames[item] {
+            let center = frame.midX
+            targetPosition = (center - containerBounds.minX) / containerBounds.width
+        }
+        
+        wobbleAmplitude = 0.04
+        startAnimation()
+    }
+    
+    func currentBlobFrame(defaultWidth: CGFloat = 80) -> CGRect {
+        guard let selected = selectedItem, let frame = itemFrames[selected] else {
+            return CGRect(
+                x: animatedPosition * containerBounds.width - defaultWidth / 2,
+                y: 0,
+                width: defaultWidth,
+                height: containerBounds.height
+            )
+        }
+        
+        var width = frame.width
+        if let previous = previousItem, let prevFrame = itemFrames[previous] {
+            let progress = 1.0 - abs(animatedPosition - targetPosition) / abs(targetPosition - (prevFrame.midX - containerBounds.minX) / containerBounds.width + 0.001)
+            width = prevFrame.width + (frame.width - prevFrame.width) * min(1, max(0, progress))
+        }
+        
+        let x = animatedPosition * containerBounds.width - width / 2 + containerBounds.minX
+        return CGRect(x: x, y: frame.minY, width: width, height: frame.height)
+    }
+    
+    private func startAnimation() {
+        guard displayLink == nil else { return }
+        let link = CADisplayLink(target: SelectionAnimationTarget<Item>(tracker: self), selector: #selector(SelectionAnimationTarget<Item>.tick))
+        link.add(to: .main, forMode: .common)
+        displayLink = link
+        lastUpdateTime = CACurrentMediaTime()
+    }
+    
+    private func stopAnimation() {
+        displayLink?.invalidate()
+        displayLink = nil
+    }
+    
+    fileprivate func update() {
+        let currentTime = CACurrentMediaTime()
+        let dt = min(currentTime - lastUpdateTime, 1.0 / 30.0)
+        lastUpdateTime = currentTime
+        
+        wobblePhase += 8.0 * dt
+        if wobblePhase > .pi * 2 { wobblePhase -= .pi * 2 }
+        wobbleAmplitude *= pow(0.92, dt * 60)
+        if wobbleAmplitude < 0.001 { wobbleAmplitude = 0 }
+        
+        let displacement = animatedPosition - targetPosition
+        let springForce = -stiffness * displacement
+        let dampingForce = -damping * stiffness * 2 * velocity
+        let acceleration = springForce + dampingForce
+        
+        velocity += acceleration * dt
+        animatedPosition += velocity * dt
+        
+        if abs(velocity) < 0.001 && abs(displacement) < 0.001 && wobbleAmplitude < 0.001 {
+            animatedPosition = targetPosition
+            velocity = 0
+            stopAnimation()
+        }
+    }
+}
+
+private class SelectionAnimationTarget<Item: Hashable & Equatable>: @unchecked Sendable {
+    weak var tracker: GelSelectionTracker<Item>?
+    
+    init(tracker: GelSelectionTracker<Item>) {
+        self.tracker = tracker
+    }
+    
+    @objc func tick() {
+        Task { @MainActor [weak self] in
+            self?.tracker?.update()
+        }
+    }
+}

--- a/GlassticPackage/Sources/GlassticFeature/Utilities/RefractiveGlass.swift
+++ b/GlassticPackage/Sources/GlassticFeature/Utilities/RefractiveGlass.swift
@@ -21,7 +21,6 @@ private struct RefractiveGlassModifier<S: Shape>: ViewModifier {
         } else {
             base.layerEffect(
                 Shader(
-                    // References `liquidGlassAdvanced` in Shaders/LiquidGlass.metal.
                     function: ShaderLibrary.liquidGlassAdvanced,
                     arguments: shaderArguments()
                 ),
@@ -32,12 +31,8 @@ private struct RefractiveGlassModifier<S: Shape>: ViewModifier {
 
     private func configuredGlass() -> Glass {
         var glass = Glass.regular
-        if let tint {
-            glass = glass.tint(tint)
-        }
-        if interactive {
-            glass = glass.interactive()
-        }
+        if let tint { glass = glass.tint(tint) }
+        if interactive { glass = glass.interactive() }
         return glass
     }
 
@@ -49,6 +44,169 @@ private struct RefractiveGlassModifier<S: Shape>: ViewModifier {
             .float(Float(refraction)),
             .float(Float(shadowOffset)),
             .float(Float(shadowBlur))
+        ]
+    }
+}
+
+private struct GelGlassModifier<S: Shape>: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    
+    let tint: Color?
+    let interactive: Bool
+    let shape: S
+    let refraction: CGFloat
+    let chromaticSpread: CGFloat
+    let glassThickness: CGFloat
+    let causticIntensity: CGFloat
+    let wobbleAmount: CGFloat
+    let time: CGFloat
+    let maxSampleOffset: CGSize
+    
+    func body(content: Content) -> some View {
+        let glass = configuredGlass()
+        let base = content.glassEffect(glass, in: shape)
+        
+        if reduceTransparency {
+            base
+        } else {
+            base.layerEffect(
+                Shader(
+                    function: ShaderLibrary.gelGlass,
+                    arguments: gelShaderArguments()
+                ),
+                maxSampleOffset: maxSampleOffset
+            )
+        }
+    }
+    
+    private func configuredGlass() -> Glass {
+        var glass = Glass.regular
+        if let tint { glass = glass.tint(tint) }
+        if interactive { glass = glass.interactive() }
+        return glass
+    }
+    
+    private func gelShaderArguments() -> [Shader.Argument] {
+        [
+            .boundingRect,
+            .float2(0.5, 0.5),
+            .float(0.7),
+            .float(Float(refraction)),
+            .float(Float(chromaticSpread)),
+            .float(Float(glassThickness)),
+            .float(Float(causticIntensity)),
+            .float(Float(time))
+        ]
+    }
+}
+
+private struct PillGelGlassModifier: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    
+    let tint: Color?
+    let interactive: Bool
+    let cornerRadius: CGFloat
+    let refraction: CGFloat
+    let chromaticSpread: CGFloat
+    let glassThickness: CGFloat
+    let causticIntensity: CGFloat
+    let wobbleAmount: CGFloat
+    let wobbleFreq: CGFloat
+    let time: CGFloat
+    let maxSampleOffset: CGSize
+    
+    func body(content: Content) -> some View {
+        let glass = configuredGlass()
+        let base = content.glassEffect(glass, in: Capsule())
+        
+        if reduceTransparency {
+            base
+        } else {
+            base.layerEffect(
+                Shader(
+                    function: ShaderLibrary.pillGelGlass,
+                    arguments: pillShaderArguments()
+                ),
+                maxSampleOffset: maxSampleOffset
+            )
+        }
+    }
+    
+    private func configuredGlass() -> Glass {
+        var glass = Glass.regular
+        if let tint { glass = glass.tint(tint) }
+        if interactive { glass = glass.interactive() }
+        return glass
+    }
+    
+    private func pillShaderArguments() -> [Shader.Argument] {
+        [
+            .boundingRect,
+            .float(Float(cornerRadius)),
+            .float(Float(refraction)),
+            .float(Float(chromaticSpread)),
+            .float(Float(glassThickness)),
+            .float(Float(causticIntensity)),
+            .float(Float(time)),
+            .float(Float(wobbleAmount)),
+            .float(Float(wobbleFreq))
+        ]
+    }
+}
+
+// MARK: - Clear Liquid Glass Modifier
+
+private struct ClearLiquidGlassModifier: ViewModifier {
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
+    
+    let cornerRadius: CGFloat
+    let refraction: CGFloat
+    let chromaticSpread: CGFloat
+    let edgeHighlight: CGFloat
+    let causticIntensity: CGFloat
+    let wobbleAmount: CGFloat
+    let wobbleFreq: CGFloat
+    let time: CGFloat
+    let maxSampleOffset: CGSize
+    
+    func body(content: Content) -> some View {
+        if reduceTransparency {
+            content
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.white.opacity(0.1))
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .stroke(Color.white.opacity(0.2), lineWidth: 1)
+                        )
+                )
+        } else {
+            content
+                .background(
+                    Capsule(style: .continuous)
+                        .fill(Color.clear)
+                )
+                .layerEffect(
+                    Shader(
+                        function: ShaderLibrary.clearLiquidGlass,
+                        arguments: shaderArguments()
+                    ),
+                    maxSampleOffset: maxSampleOffset
+                )
+        }
+    }
+    
+    private func shaderArguments() -> [Shader.Argument] {
+        [
+            .boundingRect,
+            .float(Float(cornerRadius)),
+            .float(Float(refraction)),
+            .float(Float(chromaticSpread)),
+            .float(Float(edgeHighlight)),
+            .float(Float(causticIntensity)),
+            .float(Float(time)),
+            .float(Float(wobbleAmount)),
+            .float(Float(wobbleFreq))
         ]
     }
 }
@@ -73,6 +231,90 @@ public extension View {
                 radius: radius,
                 shadowOffset: shadowOffset,
                 shadowBlur: shadowBlur,
+                maxSampleOffset: maxSampleOffset
+            )
+        )
+    }
+    
+    func gelGlass<S: Shape>(
+        tint: Color? = nil,
+        interactive: Bool = false,
+        in shape: S,
+        refraction: CGFloat = 0.15,
+        chromaticSpread: CGFloat = 0.04,
+        glassThickness: CGFloat = 0.5,
+        causticIntensity: CGFloat = 0.25,
+        wobbleAmount: CGFloat = 0.0,
+        time: CGFloat = 0,
+        maxSampleOffset: CGSize = CGSize(width: 48, height: 48)
+    ) -> some View {
+        modifier(
+            GelGlassModifier(
+                tint: tint,
+                interactive: interactive,
+                shape: shape,
+                refraction: refraction,
+                chromaticSpread: chromaticSpread,
+                glassThickness: glassThickness,
+                causticIntensity: causticIntensity,
+                wobbleAmount: wobbleAmount,
+                time: time,
+                maxSampleOffset: maxSampleOffset
+            )
+        )
+    }
+    
+    func pillGelGlass(
+        tint: Color? = nil,
+        interactive: Bool = false,
+        cornerRadius: CGFloat = 0.15,
+        refraction: CGFloat = 0.12,
+        chromaticSpread: CGFloat = 0.035,
+        glassThickness: CGFloat = 0.45,
+        causticIntensity: CGFloat = 0.2,
+        wobbleAmount: CGFloat = 0.008,
+        wobbleFreq: CGFloat = 6.0,
+        time: CGFloat = 0,
+        maxSampleOffset: CGSize = CGSize(width: 64, height: 64)
+    ) -> some View {
+        modifier(
+            PillGelGlassModifier(
+                tint: tint,
+                interactive: interactive,
+                cornerRadius: cornerRadius,
+                refraction: refraction,
+                chromaticSpread: chromaticSpread,
+                glassThickness: glassThickness,
+                causticIntensity: causticIntensity,
+                wobbleAmount: wobbleAmount,
+                wobbleFreq: wobbleFreq,
+                time: time,
+                maxSampleOffset: maxSampleOffset
+            )
+        )
+    }
+    
+    func clearLiquidGlass(
+        cornerRadius: CGFloat = 0.15,
+        refraction: CGFloat = 0.25,
+        chromaticSpread: CGFloat = 0.06,
+        edgeHighlight: CGFloat = 0.5,
+        causticIntensity: CGFloat = 0.35,
+        wobbleAmount: CGFloat = 0.012,
+        wobbleFreq: CGFloat = 5.0,
+        time: CGFloat = 0,
+        maxSampleOffset: CGSize = CGSize(width: 100, height: 100)
+    ) -> some View {
+        modifier(
+            ClearLiquidGlassModifier(
+                cornerRadius: cornerRadius,
+                refraction: refraction,
+                chromaticSpread: chromaticSpread,
+                edgeHighlight: edgeHighlight,
+                causticIntensity: causticIntensity,
+                wobbleAmount: wobbleAmount,
+                wobbleFreq: wobbleFreq,
+                time: time,
                 maxSampleOffset: maxSampleOffset
             )
         )


### PR DESCRIPTION
## Summary

- Replace frosted glass with **crystal-clear refractive glass** on the bottom pill menu
- Add custom Metal shader (`clearLiquidGlass`) with transparency, refraction, chromatic aberration, animated caustics, and gel-like wobble physics
- Includes accessibility fallback (solid background when Reduce Transparency is enabled)

## Changes

- **LiquidGlass.metal**: New `clearLiquidGlass` shader with multi-octave FBM caustics and 3-source rim lighting
- **RefractiveGlass.swift**: Add `ClearLiquidGlassModifier` and `.clearLiquidGlass()` view extension
- **GelPhysics.swift**: New utility for spring-based gel animations
- **ContentView.swift**: Update `BottomPillMenu` to use clear glass styling with enhanced selection indicator (drag-stretch, bounce effects)

## Before vs After

**Before**: Frosted/blurred glass (Apple's native `.glassEffect()`)  
**After**: Crystal-clear transparent glass with visible refraction and light play